### PR TITLE
Add docs_url() helper function for Symbiota documentation URLs

### DIFF
--- a/app/Helpers/helpers.php
+++ b/app/Helpers/helpers.php
@@ -28,3 +28,17 @@ if (! function_exists('legacy_url')) {
         );
     }
 }
+
+/**
+ * Helper to generate URLs to Symbiota documentation.
+ * Makes documentation links resilient to URL changes.
+ *
+ * @param  string  $path  Path to append to the docs base URL
+ * @return string
+ **/
+if (! function_exists('docs_url')) {
+    function docs_url(string $path = ''): string {
+        $baseUrl = 'https://biokic.github.io/symbiota-docs/';
+        return $baseUrl . ltrim($path, '/');
+    }
+}


### PR DESCRIPTION
## Summary
- Added `docs_url()` helper function to centralize Symbiota documentation URL generation
- Makes the codebase more resilient to documentation URL changes

## Changes Made
Modified `app/Helpers/helpers.php`:
- Added new `docs_url()` helper function that accepts an optional path parameter
- Base documentation URL is `https://biokic.github.io/symbiota-docs/`
- Function uses `ltrim()` to handle paths with or without leading slashes
- Follows existing helper function patterns in the file (using `function_exists()` check)

## Usage
```php
// Returns base URL: https://biokic.github.io/symbiota-docs/
docs_url()

// Returns full URL: https://biokic.github.io/symbiota-docs/editor/images/
docs_url('editor/images/')

// Also works with leading slash: https://biokic.github.io/symbiota-docs/col_obs/
docs_url('/col_obs/')
```

## Benefits
- **Single source of truth**: If the docs URL changes, only one line needs to be updated
- **Consistency**: All doc links will use the same base URL
- **Maintainability**: Easier to manage than scattered hardcoded URLs throughout the codebase

## Next Steps
This PR creates the helper function. A follow-up PR could replace existing hardcoded documentation URLs with calls to `docs_url()`.

Fixes #50