### PR TITLE
Blitz dynchecklistmap

### DIFF
--- a/app/Http/Controllers/ChecklistController.php
+++ b/app/Http/Controllers/ChecklistController.php
@@ -147,7 +147,7 @@ class ChecklistController extends Controller {
 
         \Language::load([
             'checklists/dynamicmap',
-            'checklists/checklist'
+            'checklists/checklist',
         ]);
 
         $error = null;

--- a/app/Http/Controllers/ChecklistController.php
+++ b/app/Http/Controllers/ChecklistController.php
@@ -145,6 +145,11 @@ class ChecklistController extends Controller {
         include_once legacy_path('/classes/utilities/Language.php');
         include_once legacy_path('/classes/DynamicChecklistManager.php');
 
+        \Language::load([
+            'checklists/dynamicmap',
+            'checklists/checklist'
+        ]);
+
         $error = null;
 
         $lat = filter_var(request('lat'), FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
@@ -182,7 +187,7 @@ class ChecklistController extends Controller {
             return redirect(legacy_url('checklists/checklist.php?dynclid=' . $dynClid));
         }
 
-        return view('pages/checklist/dynamic-builder', ['error' => $error]);
+        return view('pages/checklist/dynamic-builder', ['errors' => $error]);
     }
 
     public static function mapPage(Request $request) {

--- a/app/Http/Controllers/ChecklistController.php
+++ b/app/Http/Controllers/ChecklistController.php
@@ -6,6 +6,7 @@ use App\Models\UserRole;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\MessageBag;
 
 class ChecklistController extends Controller {
     public static function getChecklistData(int $clid) {
@@ -136,8 +137,52 @@ class ChecklistController extends Controller {
     }
 
     public static function dynamicMapPage(Request $request) {
-
         return view('pages/checklist/dynamic-builder');
+    }
+
+    public static function buildDynChecklist(Request $request) {
+        global $LANG, $SERVER_ROOT, $DYN_CHECKLIST_RADIUS;
+        include_once(legacy_path('/classes/utilities/Language.php'));
+        include_once(legacy_path('/classes/DynamicChecklistManager.php'));
+
+        $error = null;
+
+        $lat = filter_var(request('lat'), FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
+        $lng = filter_var(request('lng'), FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
+        $radius = filter_var(request('radius'), FILTER_SANITIZE_NUMBER_INT);
+        $radiusUnits = request('radiusunits') === 'mi'? 'mi': 'km';
+        $dynamicRadius = $DYN_CHECKLIST_RADIUS ?? 10;
+        $taxa = request('taxa');
+        $tid = filter_var(request('tid'), FILTER_SANITIZE_NUMBER_INT);
+        $interface = request('interface') === 'checklist'? 'checklist': 'key';
+
+        $dynClManager = new \DynamicChecklistManager();
+
+        if($taxa && !$tid) {
+            $tid = $dynClManager->getTid($taxa);
+        }
+
+        $dynClid = 0;
+
+        if(is_numeric($lng) && is_numeric($lng)) {
+            if($radius) {
+                $dynClid = $dynClManager->createChecklist($lat, $lng, $radius, $radiusUnits, $tid);
+            } else {
+                $dynClid = $dynClManager->createDynamicChecklist($lat, $lng, $dynamicRadius, $tid);
+            }
+        }
+
+        $dynClManager->removeOldChecklists();
+
+        if(!$dynClid) {
+            $error = new MessageBag([ $LANG['ERROR_GEN_CHECK'] ]);
+        } else if($interface == "key") {
+            return redirect(legacy_url('ident/key.php?dynclid=' . $dynClid."&taxon=All Species"));
+        } else {
+            return redirect(legacy_url('checklists/checklist.php?dynclid=' . $dynClid));
+        }
+
+        return view('pages/checklist/dynamic-builder', ['error' => $error ]);
     }
 
     public static function mapPage(Request $request) {

--- a/app/Http/Controllers/ChecklistController.php
+++ b/app/Http/Controllers/ChecklistController.php
@@ -142,30 +142,30 @@ class ChecklistController extends Controller {
 
     public static function buildDynChecklist(Request $request) {
         global $LANG, $SERVER_ROOT, $DYN_CHECKLIST_RADIUS;
-        include_once(legacy_path('/classes/utilities/Language.php'));
-        include_once(legacy_path('/classes/DynamicChecklistManager.php'));
+        include_once legacy_path('/classes/utilities/Language.php');
+        include_once legacy_path('/classes/DynamicChecklistManager.php');
 
         $error = null;
 
         $lat = filter_var(request('lat'), FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
         $lng = filter_var(request('lng'), FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
         $radius = filter_var(request('radius'), FILTER_SANITIZE_NUMBER_INT);
-        $radiusUnits = request('radiusunits') === 'mi'? 'mi': 'km';
+        $radiusUnits = request('radiusunits') === 'mi' ? 'mi' : 'km';
         $dynamicRadius = $DYN_CHECKLIST_RADIUS ?? 10;
         $taxa = request('taxa');
         $tid = filter_var(request('tid'), FILTER_SANITIZE_NUMBER_INT);
-        $interface = request('interface') === 'checklist'? 'checklist': 'key';
+        $interface = request('interface') === 'checklist' ? 'checklist' : 'key';
 
         $dynClManager = new \DynamicChecklistManager();
 
-        if($taxa && !$tid) {
+        if ($taxa && ! $tid) {
             $tid = $dynClManager->getTid($taxa);
         }
 
         $dynClid = 0;
 
-        if(is_numeric($lng) && is_numeric($lng)) {
-            if($radius) {
+        if (is_numeric($lng) && is_numeric($lng)) {
+            if ($radius) {
                 $dynClid = $dynClManager->createChecklist($lat, $lng, $radius, $radiusUnits, $tid);
             } else {
                 $dynClid = $dynClManager->createDynamicChecklist($lat, $lng, $dynamicRadius, $tid);
@@ -174,15 +174,15 @@ class ChecklistController extends Controller {
 
         $dynClManager->removeOldChecklists();
 
-        if(!$dynClid) {
-            $error = new MessageBag([ $LANG['ERROR_GEN_CHECK'] ]);
-        } else if($interface == "key") {
-            return redirect(legacy_url('ident/key.php?dynclid=' . $dynClid."&taxon=All Species"));
+        if (! $dynClid) {
+            $error = new MessageBag([$LANG['ERROR_GEN_CHECK']]);
+        } elseif ($interface == 'key') {
+            return redirect(legacy_url('ident/key.php?dynclid=' . $dynClid . '&taxon=All Species'));
         } else {
             return redirect(legacy_url('checklists/checklist.php?dynclid=' . $dynClid));
         }
 
-        return view('pages/checklist/dynamic-builder', ['error' => $error ]);
+        return view('pages/checklist/dynamic-builder', ['error' => $error]);
     }
 
     public static function mapPage(Request $request) {

--- a/resources/views/core/pages/checklist/dynamic-builder.blade.php
+++ b/resources/views/core/pages/checklist/dynamic-builder.blade.php
@@ -1,34 +1,28 @@
 @props(['errors'])
-@php
-global $LANG;
-include_once(legacy_path('/classes/utilities/Language.php'));
-
-Language::load([
-	'checklists/dynamicmap',
-	'checklists/checklist'
-]);
-
-@endphp
-
 <x-margin-layout>
     <x-breadcrumbs :items="[
-        ['title' => $LANG['HOME'], 'href' => url('')],
-        ['title' => $LANG['DYNAMIC_MAP']],
-        ]" />
+        ['title' => __('header.H_HOME'), 'href' => url('')],
+        ['title' => __('checklists_checklist.DYNAMIC_MAP')],
+    ]" />
 
-    <h1 class="sr-only">{{ $LANG['DYNAMIC_MAP'] }}></h1>
+    <h1 class="sr-only">{{ __('checklists_dynamicmap.DYNAMIC_MAP') }}></h1>
 
     <div class="flex flex-col gap-1" x-data="{'moreDetail': false}">
         <p>
-            {{ $LANG['CAPTURE_COORDS'] }}
+            {{ __('checklists_dynamicmap.CAPTURE_COORDS') }}
         <p/>
 
         <p x-show="moreDetail">
-            {{ $LANG['RADIUS_DESCRIPTION'] }}
+            {{ __('checklists_dynamicmap.RADIUS_DESCRIPTION') }}
         <p/>
+
         <x-button class="cursor-pointer" @click="moreDetail=!moreDetail">
-            <span x-show="moreDetail">{{ $LANG['LESS_DETAILS'] }}</span>
-            <span x-show="!moreDetail">{{ $LANG['MORE_DETAILS'] }}</span>
+            <span x-show="moreDetail">
+                {{ __('checklists_dynamicmap.LESS_DETAILS') }}
+            </span>
+            <span x-show="!moreDetail">
+                {{ __('checklists_dynamicmap.MORE_DETAILS') }}
+            </span>
         </x-button>
     </div>
     <form method="post" class="flex flex-col gap-4">
@@ -36,19 +30,19 @@ Language::load([
         <div class="flex flex-wrap items-center gap-2">
             <input type="hidden" name="interface" value="{{ request('interface') ?? 'checklist' }}" />
             <input type="hidden" name="buildChecklist" value="1" />
-            <div class="min-w-20 max-w-40 flex-grow"><x-input id="lat" label="Latitude" value=""/></div>
-            <div class="min-w-20 max-w-40 flex-grow"><x-input id="lng" label="Longitude" value=""/></div>
-            <div class="min-w-20 max-w-40 flex-grow"><x-input id="radius" label="Radius" type="number" /></div>
-            <x-select class="min-w-10 flex-grow" id="radiusunits" label="Units" default="0" :items="[
-            ['title' => $LANG['KM'], 'value' => 'km' ],
-            ['title' => $LANG['MILES'], 'value' => 'mi' ]
-        ]" />
+            <div class="min-w-20 max-w-40 flex-grow"><x-input id="lat" :label="__('tools_mapaids.MPR_LAT')" value=""/></div>
+            <div class="min-w-20 max-w-40 flex-grow"><x-input id="lng" :label="__('tools_mapaids.MPR_LNG')" value=""/></div>
+            <div class="min-w-20 max-w-40 flex-grow"><x-input id="radius" :label="__('checklists_dynamicmap.RADIUS')" type="number" /></div>
+            <x-select class="min-w-10 flex-grow" id="radiusunits" :label="__('checklists_dynamicmap.UNITS')" default="0" :items="[
+                item('km', __('checklists_dynamicmap.KM')),
+                item('mi', __('checklists_dynamicmap.MILES'))
+            ]"/>
         </div>
 
-        <x-taxa-search class="z-100" label="Taxon Filter" />
+        <x-taxa-search class="z-100" :label="__('checklists_dynamicmap.TAXON_FILTER')" />
 
         <div>
-            <x-button>{{ $LANG['BUILD_CHECKLIST'] }}</x-button>
+            <x-button>{{ __('checklists_dynamicmap.BUILD_CHECKLIST') }}</x-button>
         </div>
 
         <x-errors :errors="$errors" />

--- a/resources/views/core/pages/checklist/dynamic-builder.blade.php
+++ b/resources/views/core/pages/checklist/dynamic-builder.blade.php
@@ -1,8 +1,7 @@
 @props(['errors'])
 @php
-global $LANG, $SERVER_ROOT, $DYN_CHECKLIST_RADIUS, $CLIENT_ROOT;
+global $LANG;
 include_once(legacy_path('/classes/utilities/Language.php'));
-include_once(legacy_path('/classes/DynamicChecklistManager.php'));
 
 Language::load([
 	'checklists/dynamicmap',
@@ -13,9 +12,11 @@ Language::load([
 
 <x-margin-layout>
     <x-breadcrumbs :items="[
-        ['title' => 'Home', 'href' => url('')],
-        ['title' => 'Dynamic Map'],
+        ['title' => $LANG['HOME'], 'href' => url('')],
+        ['title' => $LANG['DYNAMIC_MAP']],
         ]" />
+
+    <h1 class="sr-only">{{ $LANG['DYNAMIC_MAP'] }}></h1>
 
     <x-errors :errors="$errors" />
 
@@ -32,7 +33,7 @@ Language::load([
             <span x-show="!moreDetail">{{ $LANG['MORE_DETAILS'] }}</span>
         </x-button>
     </div>
-    <form method="post">
+    <form method="post" class="flex flex-col gap-4">
         @csrf
         <div class="flex flex-wrap items-center gap-2">
             <input type="hidden" name="interface" value="{{ request('interface') ?? 'checklist' }}" />
@@ -41,8 +42,8 @@ Language::load([
             <div class="min-w-20 max-w-40 flex-grow"><x-input id="lng" label="Longitude" value=""/></div>
             <div class="min-w-20 max-w-40 flex-grow"><x-input id="radius" label="Radius" type="number" /></div>
             <x-select class="min-w-10 flex-grow" id="radiusunits" label="Units" default="0" :items="[
-            ['title' => 'Kilometers', 'value' => 'km' ],
-            ['title' => 'Miles', 'value' => 'mi' ]
+            ['title' => $LANG['KM'], 'value' => 'km' ],
+            ['title' => $LANG['MILES'], 'value' => 'mi' ]
         ]" />
         </div>
 

--- a/resources/views/core/pages/checklist/dynamic-builder.blade.php
+++ b/resources/views/core/pages/checklist/dynamic-builder.blade.php
@@ -18,8 +18,6 @@ Language::load([
 
     <h1 class="sr-only">{{ $LANG['DYNAMIC_MAP'] }}></h1>
 
-    <x-errors :errors="$errors" />
-
     <div class="flex flex-col gap-1" x-data="{'moreDetail': false}">
         <p>
             {{ $LANG['CAPTURE_COORDS'] }}
@@ -52,6 +50,8 @@ Language::load([
         <div>
             <x-button>{{ $LANG['BUILD_CHECKLIST'] }}</x-button>
         </div>
+
+        <x-errors :errors="$errors" />
     </form>
 
     <script>

--- a/resources/views/core/pages/checklist/dynamic-builder.blade.php
+++ b/resources/views/core/pages/checklist/dynamic-builder.blade.php
@@ -1,28 +1,107 @@
-<x-layout class="flex flex-col gap-4">
+@props(['errors'])
+@php
+global $LANG, $SERVER_ROOT, $DYN_CHECKLIST_RADIUS, $CLIENT_ROOT;
+include_once(legacy_path('/classes/utilities/Language.php'));
+include_once(legacy_path('/classes/DynamicChecklistManager.php'));
+
+Language::load([
+	'checklists/dynamicmap',
+	'checklists/checklist'
+]);
+
+@endphp
+
+<x-margin-layout>
     <x-breadcrumbs :items="[
         ['title' => 'Home', 'href' => url('')],
         ['title' => 'Dynamic Map'],
         ]" />
-    <div>
-        Description
-    </div>
 
-    <div>
-        Point (Lat, Long) (click on map)
-    </div>
+    <x-errors :errors="$errors" />
 
-    <x-taxa-search label="Taxon Filter" />
-    <div>
-        <x-button>Build Checklist</x-button>
-    </div>
+    <div class="flex flex-col gap-1" x-data="{'moreDetail': false}">
+        <p>
+            {{ $LANG['CAPTURE_COORDS'] }}
+        <p/>
 
-    <div class="flex items-center gap-2">
-        <x-input name="radius" />
-        <x-select name="units" :items="[
-        ['title' => 'Kilometers', 'value' => 'kilometers' ],
-        ['title' => 'Miles', 'value' => 'miles' ]
-    ]" />
+        <p x-show="moreDetail">
+            {{ $LANG['RADIUS_DESCRIPTION'] }}
+        <p/>
+        <x-button class="cursor-pointer" @click="moreDetail=!moreDetail">
+            <span x-show="moreDetail">{{ $LANG['LESS_DETAILS'] }}</span>
+            <span x-show="!moreDetail">{{ $LANG['MORE_DETAILS'] }}</span>
+        </x-button>
     </div>
+    <form method="post">
+        @csrf
+        <div class="flex flex-wrap items-center gap-2">
+            <input type="hidden" name="interface" value="{{ request('interface') ?? 'checklist' }}" />
+            <input type="hidden" name="buildChecklist" value="1" />
+            <div class="min-w-20 max-w-40 flex-grow"><x-input id="lat" label="Latitude" value=""/></div>
+            <div class="min-w-20 max-w-40 flex-grow"><x-input id="lng" label="Longitude" value=""/></div>
+            <div class="min-w-20 max-w-40 flex-grow"><x-input id="radius" label="Radius" type="number" /></div>
+            <x-select class="min-w-10 flex-grow" id="radiusunits" label="Units" default="0" :items="[
+            ['title' => 'Kilometers', 'value' => 'km' ],
+            ['title' => 'Miles', 'value' => 'mi' ]
+        ]" />
+        </div>
 
-    <x-map />
-</x-layout>
+        <x-taxa-search class="z-100" label="Taxon Filter" />
+
+        <div>
+            <x-button>{{ $LANG['BUILD_CHECKLIST'] }}</x-button>
+        </div>
+    </form>
+
+    <script>
+        document.addEventListener('mapIntialized', function (e) {
+            let map = window.maps['map'];
+            let markerGroup = new L.layerGroup().addTo(map);
+            let latlng;
+
+            const radiusEl = document.getElementById('radius');
+            const radiusUnitsEl = document.getElementById('radiusunits');
+            const latEl= document.getElementById('lat');
+            const lngEl= document.getElementById('lng');
+
+            function getRadius() {
+                if(radiusUnitsEl.value === "km") return radiusEl.value * 1000;
+                const MILES_TO_METERS = 1609.344;
+                return radiusEl.value * MILES_TO_METERS;
+            }
+
+            function drawMarker(lat, lng) {
+                //Clear Layers In Between Clicks
+                if(markerGroup) markerGroup.clearLayers();
+
+                lat = lat = parseFloat(lat);
+                lng = lng = parseFloat(lng);
+
+                if((lat >= -90 || lat <= 90) && (lng >= -180 || lng <= 180)) {
+                    latlng = {lat, lng};
+                    //Render Marker
+                    L.marker(latlng).addTo(markerGroup);
+                    let radius = getRadius();
+                    //Render Radius if Input
+                    if(radius > 0) {
+                        let circle = L.circle(latlng, radius)
+                            .setStyle(DEFAULT_SHAPE_OPTIONS)
+                            .addTo(markerGroup);
+                    }
+
+                    map.setView(latlng, map.getZoom());
+                }
+            }
+
+            radiusEl.addEventListener('input', () => drawMarker(latlng.lat, latlng.lng));
+            latEl.addEventListener('change', (e) => drawMarker(e.target.value, lngEl.value));
+            lngEl.addEventListener('change', (e) => drawMarker(latEl.value, e.target.value));
+            map.on('click', (e) => {
+                drawMarker(e.latlng.lat, e.latlng.lng)
+                latEl.value = e.latlng.lat;
+                lngEl.value = e.latlng.lng;
+            });
+        })
+    </script>
+    <x-map class="z-0"/>
+</x-margin-layout>

--- a/resources/views/core/pages/sitemap.blade.php
+++ b/resources/views/core/pages/sitemap.blade.php
@@ -110,11 +110,11 @@
         <h2 class="text-2xl text-primary font-bold">Dynamic Species Lists</h2>
         <ul class="list-disc pl-4">
             <li>
-                <x-link href="{{ legacy_url('/checklists/dynamicmap.php?interface=checklist') }}">
+                <x-link href="{{ url('checklists/dynamicmap?interface=checklist') }}">
                     Checklist </x-link> - dynamically build a checklist using georeferenced specimen records
             </li>
             <li>
-                <x-link href="{{ legacy_url('/checklists/dynamicmap.php?interface=key') }}">
+                <x-link href="{{ url('checklists/dynamicmap?interface=key') }}">
                     Dynamic Key </x-link> - dynamically build a key using georeferenced specimen records
             </li>
         </ul>

--- a/routes/web.php
+++ b/routes/web.php
@@ -64,6 +64,7 @@ Route::group(['prefix' => 'taxon'], function () {
 Route::group(['prefix' => 'checklists'], function () {
     Route::get('/', [ChecklistController::class, 'checklists']);
     Route::get('/dynamicmap', [ChecklistController::class, 'dynamicMapPage']);
+    Route::post('/dynamicmap', [ChecklistController::class, 'buildDynChecklist']);
     Route::get('/map', [ChecklistController::class, 'mapPage']);
     Route::post('/create', [ChecklistController::class, 'createChecklist']);
     Route::get('/{clid}/admin', [ChecklistController::class, 'getAdminPage']);


### PR DESCRIPTION
# Issue #59 

# Summary
Adds dynamic checklist builder page.
Currently redirects to old checklist page because dynamic checklist is not support and it a active item on those pages.

Existing error handling on this page were very vague if any at all. Something to note and maybe make an issue to enhance.
 
# Pull Request Checklist During the Blitz Phase:

# Pre-Approval, Blitz Phase
- [ ] Are (basic) tests written to cover the new functionality?
- [x] If there is text in this PR that has not been internationalized, implementing this is not required; add a @TODO comment and create a github issue about it.
- [x] There are no linter errors
- [x] Has Pint been run?

# Code Review, Blitz Phase
- [x] Build a dynamic checklist (Make sure checklist/checklist.php  is redirect)
- [x] Build a dynamic key (Make sure ident/key is redirect)

# Cleanup
- [ ] PR should be squash merged