### PR TITLE
Blitz skeletal Submit

### DIFF
--- a/app/Http/Controllers/CollectionController.php
+++ b/app/Http/Controllers/CollectionController.php
@@ -114,14 +114,14 @@ class CollectionController extends Controller {
     }
     public static function skeletalView(int $collId) {
         return view('pages/collections/skeletal-submit', [
-            'collection' => Collection::query()->where('collid', $collId)->first()
+            'collection' => Collection::query()->where('collid', $collId)->first(),
         ]);
     }
 
     public static function skeletalAdd(int $collId) {
         global $SERVER_ROOT;
-        include_once(legacy_path('/classes/OccurrenceEditorManager.php'));
-        include_once(legacy_path('/classes/GeographicThesaurus.php'));
+        include_once legacy_path('/classes/OccurrenceEditorManager.php');
+        include_once legacy_path('/classes/GeographicThesaurus.php');
 
         $occurrenceEditor = new \OccurrenceEditorManager();
         $occurrenceEditor->setCollId($collId);
@@ -134,46 +134,46 @@ class CollectionController extends Controller {
         $status = true;
         $error = false;
 
-        if(request('stateprovince') && request('country')) {
+        if (request('stateprovince') && request('country')) {
             $occurrence['country'] = \GeographicThesaurus::getCountryByState(request('stateprovince'));
         }
 
-        if(request('catalognumber') && $occurrenceEditor->catalogNumberExists(request('catalognumber'))) {
-			$occid = $occurrenceEditor->getOccId();
-			if(request('addaction') == '1') {
+        if (request('catalognumber') && $occurrenceEditor->catalogNumberExists(request('catalognumber'))) {
+            $occid = $occurrenceEditor->getOccId();
+            if (request('addaction') == '1') {
                 $status = false;
-				$error = 'dupeCatalogNumber';
-			}
-			elseif(request('addaction') == '2') {
-				if(!$occurrenceEditor->editOccurrence($occurrence, $isEditor)){
+                $error = 'dupeCatalogNumber';
+            } elseif (request('addaction') == '2') {
+                if (! $occurrenceEditor->editOccurrence($occurrence, $isEditor)) {
                     $error = $occurrenceEditor->getErrorStr();
-				}
-			}
+                }
+            }
         } else {
-			if($occurrenceEditor->addOccurrence($occurrence)) {
-				$occid = $occurrenceEditor->getOccId();
-			} else {
+            if ($occurrenceEditor->addOccurrence($occurrence)) {
+                $occid = $occurrenceEditor->getOccId();
+            } else {
                 $error = $occurrenceEditor->getErrorStr();
-			}
+            }
         }
 
-        if($error) {
+        if ($error) {
             return response(
                 Blade::render(
                     '<x-errors :errors="$errors" />',
                     ['errors' => message_bag([$error])]
                 )
             )->header('HX-Retarget', 'div[id=form-errors]')
-             ->header('HX-Reswap', 'innerHTML');
+                ->header('HX-Reswap', 'innerHTML');
         } else {
-            $url = legacy_url("collections/editor/occurrenceeditor.php?occid=" . $occid . "&collid=" . $collId);
+            $url = legacy_url('collections/editor/occurrenceeditor.php?occid=' . $occid . '&collid=' . $collId);
+
             return response(
                 Blade::render(
                     '<div class="flex gap-2">
                         <x-link target="_blank" :href="$url">{{ $occid }}</x-link>
                         <x-link target="_blank" :href="$url . \'&tabtarget=2\'"><i class="fa-solid fa-file-image"></i></x-link>
                     </div>',
-                    ['occid' => $occid, 'url' => $url ]
+                    ['occid' => $occid, 'url' => $url]
                 )
             );
         }

--- a/app/Http/Controllers/CollectionController.php
+++ b/app/Http/Controllers/CollectionController.php
@@ -112,6 +112,7 @@ class CollectionController extends Controller {
             $collManager->updateStatistics(true);
         }, 200, ['X-Accel-Buffering' => 'no']);
     }
+
     public static function skeletalView(int $collId) {
         return view('pages/collections/skeletal-submit', [
             'collection' => Collection::query()->where('collid', $collId)->first(),

--- a/app/Http/Controllers/CollectionController.php
+++ b/app/Http/Controllers/CollectionController.php
@@ -127,8 +127,6 @@ class CollectionController extends Controller {
         $occurrenceEditor->setCollId($collId);
         $occurrence = request()->all();
         $occurrence['collid'] = $collId;
-        $isEditor = true;
-        // $responseArr = [];
 
         $occid = true;
         $status = true;
@@ -144,7 +142,8 @@ class CollectionController extends Controller {
                 $status = false;
                 $error = 'dupeCatalogNumber';
             } elseif (request('addaction') == '2') {
-                if (! $occurrenceEditor->editOccurrence($occurrence, $isEditor)) {
+                // Editor is always an editor because route has auth middleware for editors
+                if (! $occurrenceEditor->editOccurrence($occurrence, true)) {
                     $error = $occurrenceEditor->getErrorStr();
                 }
             }

--- a/app/Http/Controllers/CollectionController.php
+++ b/app/Http/Controllers/CollectionController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Collection;
 use App\Models\Occurrence;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
@@ -110,6 +111,72 @@ class CollectionController extends Controller {
         return response()->stream(function () use ($collManager) {
             $collManager->updateStatistics(true);
         }, 200, ['X-Accel-Buffering' => 'no']);
+    }
+    public static function skeletalView(int $collId) {
+        return view('pages/collections/skeletal-submit', [
+            'collection' => Collection::query()->where('collid', $collId)->first()
+        ]);
+    }
+
+    public static function skeletalAdd(int $collId) {
+        global $SERVER_ROOT;
+        include_once(legacy_path('/classes/OccurrenceEditorManager.php'));
+        include_once(legacy_path('/classes/GeographicThesaurus.php'));
+
+        $occurrenceEditor = new \OccurrenceEditorManager();
+        $occurrenceEditor->setCollId($collId);
+        $occurrence = request()->all();
+        $occurrence['collid'] = $collId;
+        $isEditor = true;
+        // $responseArr = [];
+
+        $occid = true;
+        $status = true;
+        $error = false;
+
+        if(request('stateprovince') && request('country')) {
+            $occurrence['country'] = \GeographicThesaurus::getCountryByState(request('stateprovince'));
+        }
+
+        if(request('catalognumber') && $occurrenceEditor->catalogNumberExists(request('catalognumber'))) {
+			$occid = $occurrenceEditor->getOccId();
+			if(request('addaction') == '1') {
+                $status = false;
+				$error = 'dupeCatalogNumber';
+			}
+			elseif(request('addaction') == '2') {
+				if(!$occurrenceEditor->editOccurrence($occurrence, $isEditor)){
+                    $error = $occurrenceEditor->getErrorStr();
+				}
+			}
+        } else {
+			if($occurrenceEditor->addOccurrence($occurrence)) {
+				$occid = $occurrenceEditor->getOccId();
+			} else {
+                $error = $occurrenceEditor->getErrorStr();
+			}
+        }
+
+        if($error) {
+            return response(
+                Blade::render(
+                    '<x-errors :errors="$errors" />',
+                    ['errors' => message_bag([$error])]
+                )
+            )->header('HX-Retarget', 'div[id=form-errors]')
+             ->header('HX-Reswap', 'innerHTML');
+        } else {
+            $url = legacy_url("collections/editor/occurrenceeditor.php?occid=" . $occid . "&collid=" . $collId);
+            return response(
+                Blade::render(
+                    '<div class="flex gap-2">
+                        <x-link target="_blank" :href="$url">{{ $occid }}</x-link>
+                        <x-link target="_blank" :href="$url . \'&tabtarget=2\'"><i class="fa-solid fa-file-image"></i></x-link>
+                    </div>',
+                    ['occid' => $occid, 'url' => $url ]
+                )
+            );
+        }
     }
 }
 

--- a/lang/en/editor_skeletalsubmit.php
+++ b/lang/en/editor_skeletalsubmit.php
@@ -46,4 +46,5 @@ return [
     'ERROR_NO_ID' => 'ERROR: collection identifier not set',
     'CLEAR' => 'Clear Form',
     'AUTHORSHIP' => 'Authorship',
+    'PROTECT_LOCALITY_DETAILS_FROM_PUBLIC' => 'Protect locality details from general public',
 ];

--- a/lang/es/editor_skeletalsubmit.php
+++ b/lang/es/editor_skeletalsubmit.php
@@ -46,4 +46,5 @@ return [
     'ERROR_NO_ID' => 'ERROR: identificador de colección no establecido',
     'CLEAR' => 'Borrar formulario',
     'AUTHORSHIP' => 'Authoría',
+    'PROTECT_LOCALITY_DETAILS_FROM_PUBLIC' => 'Protéger détails de localité du grand public',
 ];

--- a/lang/fr/editor_skeletalsubmit.php
+++ b/lang/fr/editor_skeletalsubmit.php
@@ -42,4 +42,5 @@ return [
     'ERROR_NO_ID' => 'ERREUR : identifiant de collection non défini',
     'CLEAR' => 'Effacer le formulaire',
     'AUTHORSHIP' => 'Paternité',
+    'PROTECT_LOCALITY_DETAILS_FROM_PUBLIC' => 'Proteger detalles de localidad del público en general',
 ];

--- a/resources/views/core/input.blade.php
+++ b/resources/views/core/input.blade.php
@@ -1,10 +1,14 @@
-@props(['id'=> uniqid(), 'name', 'label' => false, 'error_text', 'assistive_text', 'area' => false, 'inline' => false])
+@props(['id'=> uniqid(), 'name', 'label' => false, 'error_text', 'assistive_text', 'area' => false, 'inline' => false, 'x-show'])
+
+{{ $attributes['x-show'] }}
 <!-- resources/views/core/input.blade.php -->
 <div @class([
         'group text-base-content',
         'flex flex-wrap items-center gap-1' => $inline,
         'w-full' => !$inline
-    ])>
+    ])
+    @isset(${'x-show'})x-show="{{ ${'x-show'} }}"@endisset
+>
     @if($label)
     <label @class(['text-base-content text-base font-bold', 'mb-1' => !$inline, 'flex items-center' => $inline])>
         {{ $label }}

--- a/resources/views/core/input.blade.php
+++ b/resources/views/core/input.blade.php
@@ -1,6 +1,5 @@
 @props(['id'=> uniqid(), 'name', 'label' => false, 'error_text', 'assistive_text', 'area' => false, 'inline' => false, 'x-show'])
 
-{{ $attributes['x-show'] }}
 <!-- resources/views/core/input.blade.php -->
 <div @class([
         'group text-base-content',

--- a/resources/views/core/pages/collections/skeletal-submit.blade.php
+++ b/resources/views/core/pages/collections/skeletal-submit.blade.php
@@ -1,0 +1,203 @@
+@props(['collection'])
+<x-margin-layout
+    x-data="{
+        show_description: false,
+        seconds: 0,
+        record_cnt: 0,
+        timerUpdate() {
+            this.seconds++;
+            $el.querySelector('#seconds').innerHTML = `${this.seconds % 60}`.padStart(2, '0');
+            $el.querySelector('#minutes').innerHTML = `${parseInt(this.seconds/60,10)}`.padStart(2, '0');
+            $el.querySelector('#count').innerHTML = this.record_cnt;
+            $el.querySelector('#rate').innerHTML = Math.round(3660 * this.record_cnt / this.seconds);
+        },
+        show_taxa: true,
+        show_authorship: true,
+        show_family: true,
+        show_security: true,
+        show_country: false,
+        show_state: true,
+        show_county: true,
+        show_collector: false,
+        show_collector_number: false,
+        show_collector_date: false,
+        show_label_project: false,
+        show_processing_staus: false,
+        show_language: false,
+        show_exsiccata: false,
+        show_other_catalognumbers: false,
+    }"
+    x-init="setInterval(() => timerUpdate(), 1000)"
+>
+    <x-breadcrumbs :items="[
+        ['title' => __('header.H_HOME'), 'href' => url('') ],
+        ['title' => __('editor_skeletalsubmit.COL_MNGMT'), 'href' => url('/collections/' . request('collid')) ],
+        ['title' => __('editor_skeletalsubmit.OCC_SKEL_SUBMIT')],
+    ]"/>
+    <div>
+        <h1 class="text-4xl font-bold font-sans">
+            {{ __('editor_skeletalsubmit.OCC_SKEL_SUBMIT') }}
+        </h1>
+        <h2 class="text-2xl font-bold font-sans">
+            {{ $collection->collectionName }}
+        </h2>
+    </div>
+
+    <div>
+        <div class="flex items-center gap-2">
+            <div class="text-2xl font-bold">
+                {{ __('editor_skeletalsubmit.SKELETAL_DATA') }}
+            </div>
+            <x-button
+                class="rounded-full h-5 w-5 justify-center"
+                @click="show_description=!show_description"
+                title="{{ __('editor_skeletalsubmit.TOOL_DESCRIPTION') }}"
+            >
+                ?
+            </x-button>
+            <div class="flex-grow"></div>
+            <x-text-label class="flex-grow flex justify-end" :label="__('editor_skeletalsubmit.SESSION')">
+                <span id="minutes">00</span>:<span id="seconds">00</span>
+            </x-text-label>
+            <x-text-label :label="__('individual.COUNT')">
+                <span id="count">0</span>
+            </x-text-label>
+
+            <x-text-label :label="__('editor_skeletalsubmit.RATE')">
+                <span id="rate">0</span> {{ __('editor_skeletalsubmit.PER_HOUR') }}
+            </x-text-label>
+        </div>
+        <hr/>
+    </div>
+
+    <div x-show="show_description" class="flex flex-col gap-2">
+        <p>
+            {{ __('editor_skeletalsubmit.SKELETAL_DESCIPRTION_1') }}
+        </p>
+        <p>
+            {{ __('editor_skeletalsubmit.SKELETAL_DESCIPRTION_2') }}
+        </p>
+        <p>
+            {{ __('editor_skeletalsubmit.SKELETAL_DESCIPRTION_3') }}
+        </p>
+    </div>
+
+    <x-accordion :label="__('editor_skeletalsubmit.DISPLAY_OPTIONS')" :open="false">
+        <div class="flex flex-col gap-2">
+            @foreach([
+                ['label' => __('cleaning.OTHER_CAT_NUMS'), 'show' => 'show_other_catalognumbers'],
+                ['label' => __('editor_skeletalsubmit.AUTHORSHIP'), 'show' => 'show_authorship'],
+                ['label' => __('taxa.FAMILY'), 'show' => 'show_family'],
+                ['label' => __('editor_skeletalsubmit.SECURITY'), 'show' => 'show_security'],
+                ['label' => __('collections_list.COUNTRY'), 'show' => 'show_country'],
+                ['label' => __('collections_list.STATE_PROVINCE'), 'show' => 'show_state'],
+                ['label' => __('editor_skeletalsubmit.COUNTY_PARISH'), 'show' => 'show_county'],
+                ['label' => __('collections_list.COLLECTOR'), 'show' => 'show_collector'],
+                ['label' => __('editor_skeletalsubmit.COLLECTOR_NO'), 'show' => 'show_collector_number'],
+                ['label' => __('editor_skeletalsubmit.COLLECTION_DATE'), 'show' => 'show_collector_date'],
+                ['label' => __('editor_skeletalsubmit.LABEL_PROJECT'), 'show' => 'show_label_project'],
+                ['label' => __('editor_skeletalsubmit.PROCESSING_STATUS'), 'show' => 'show_processing_staus'],
+                ['label' => __('glossary_addterm.LANGUAGE'), 'show' => 'show_language'],
+                ['label' => __('editor_skeletalsubmit.EXSICCATA'), 'show' => 'show_exsiccata'],
+            ] as $checkbox)
+                <x-checkbox :label="$checkbox['label']" x-bind:checked="{{$checkbox['show']}}" x-on:change="{{ $checkbox['show'] }}=$event.target.checked"/>
+            @endforeach
+            <x-radio :label="__('editor_skeletalsubmit.CATNUM_MATCH')" name="addaction" :options="[
+                ['label' => __('editor_skeletalsubmit.RESTRICT_IF_EXISTS'), 'value' => 1],
+                ['label' => __('editor_skeletalsubmit.APPEND_VALUES'), 'value' => 2],
+            ]"
+            />
+        </div>
+    </x-accordion>
+
+    @fragment('skeletal-submit')
+    <form
+        class="flex flex-col gap-2"
+        hx-post="{{ url()->current() }}"
+        hx-include="input[name=addaction]"
+        hx-target="#skeletal-session-records"
+        hx-swap="afterbegin"
+        x-data="{ form: $el }"
+    >
+        @csrf
+        <div x-show="show_taxa">
+            <x-taxa-search name="sciname"/>
+        </div>
+        <x-input name="scientificnameauthorship" :label="__('editor_skeletalsubmit.AUTHORSHIP')" x-show="show_authorship"/>
+        @can('TAXONOMY')
+        <x-button :href="url('taxon/create')">
+            {{ __('lang_sitemap.ADDTAXANAME')}}
+        </x-button>
+        @endcan
+        <x-input name="family" :label="__('taxa.FAMILY')" x-show="show_family"/>
+
+        <x-checkbox name="recordsecurity" :label="__('editor_skeletalsubmit.PROTECT_LOCALITY_DETAILS_FROM_PUBLIC')" x-show="show_security"/>
+
+        <div class="flex gap-2" x-show="show_country || show_state || show_county">
+            <x-input name="country" :label="__('collections_list.COUNTRY')" x-show="show_country"/>
+            <x-input name="stateprovince" :label="__('collections_list.STATE_PROVINCE')" x-show="show_state"/>
+            <x-input name="county" :label="__('editor_skeletalsubmit.COUNTY_PARISH')" x-show="show_county"/>
+        </div>
+
+        <div class="flex gap-2" x-show="show_collector || show_collector_number || show_collector_date">
+            <x-input name="recordedby" :label="__('collections_list.COLLECTOR')" x-show="show_collector"/>
+            <x-input name="recordnumber" :label="__('editor_skeletalsubmit.COLLECTOR_NO')" x-show="show_collector_number"/>
+            <x-input name="eventdate" :label="__('editor_skeletalsubmit.COLLECTION_DATE')" x-show="show_collector_date"/>
+        </div>
+
+        <div class="flex gap-2" x-show="show_label_project || show_processing_staus || show_language">
+            <x-input name="labelproject" :label="__('editor_skeletalsubmit.LABEL_PROJECT')" x-show="show_label_project"/>
+            <x-select
+                default="0"
+                class="w-full"
+                name="processingstatus"
+                :label="__('editor_skeletalsubmit.PROCESSING_STATUS')"
+                :items="[
+                    item('Select Status', 'Select Status'),
+                    item(__('editor_occurrencetable_display.UNPROCESSED'), 'unprocessed'),
+                    item(__('editor_occurrencetable_display.STAGE_1'), 'stage 1'),
+                    item(__('editor_occurrencetable_display.STAGE_2'), 'stage 2'),
+                    item(__('editor_occurrencetable_display.STAGE_3'), 'stage 3'),
+                    item(__('editor_occurrencetable_display.EXPERT_REQUIRED'), 'expert required'),
+                    item(__('editor_occurrencetable_display.PENDING_REVIEW_NFN'), 'pending review-nfn'),
+                    item(__('editor_occurrencetable_display.PENDING_REVIEW'), 'pending review'),
+                    item(__('editor_occurrencetable_display.REVIEWED'), 'reviewed'),
+                    item(__('editor_occurrencetable_display.CLOSED'), 'CLOSED'),
+                ]"
+                x-show="show_processing_staus"
+            />
+            <x-input name="language" :label="__('glossary_addterm.LANGUAGE')" x-show="show_language"/>
+        </div>
+
+        {{-- TODO EXSICCATA search --}}
+        <div class="flex gap-2" x-show="show_exsiccata">
+            <x-input name="exstitle" :label="__('editor_skeletalsubmit.EXSTITLE')"/>
+            <input type="hidden" id="ometid" name="ometid"/>
+            <x-input name="exsnumber" :label="__('editor_skeletalsubmit.EXSNUMBER')"/>
+        </div>
+
+        <div class="flex gap-2">
+            <x-input name="catalognumber" :label="__('editor_skeletalsubmit.CATALOGNUMBER')" required />
+            <x-input name="othercatalognumbers" :label="__('cleaning.OTHER_CAT_NUMS')" x-show="show_other_catalognumbers"/>
+        </div>
+
+        <div class="flex gap-2">
+            <x-button>
+                {{ __('editor_skeletalsubmit.ADD_RECORD')}}
+            </x-button>
+
+            <x-button type="button" variant="neutral" @click="form.reset()">
+                {{ __('editor_skeletalsubmit.CLEAR')}}
+            </x-button>
+        </div>
+        <div id="form-errors"></div>
+    </form>
+    @endfragment
+
+    <div>
+        <div class="text-2xl font-bold capitalize">{{ __('imagelib_search.RECORDS') }}</div>
+        <hr/>
+    </div>
+    <div id="skeletal-session-records" x-on:htmx:after-swap="record_cnt = $el.children.length">
+    </div>
+</x-margin-layout>

--- a/resources/views/core/pages/collections/skeletal-submit.blade.php
+++ b/resources/views/core/pages/collections/skeletal-submit.blade.php
@@ -126,7 +126,7 @@
         <x-input name="scientificnameauthorship" :label="__('editor_skeletalsubmit.AUTHORSHIP')" x-show="show_authorship"/>
         @can('TAXONOMY')
         <x-button :href="url('taxon/create')">
-            {{ __('lang_sitemap.ADDTAXANAME')}}
+            {{ __('sitemap.ADDTAXANAME')}}
         </x-button>
         @endcan
         <x-input name="family" :label="__('taxa.FAMILY')" x-show="show_family"/>
@@ -183,7 +183,7 @@
 
         <div class="flex gap-2">
             <x-button>
-                {{ __('editor_skeletalsubmit.ADD_RECORD')}}
+                {{ __('profile_occurrencemenu.ADD_RECORD')}}
             </x-button>
 
             <x-button type="button" variant="neutral" @click="form.reset()">

--- a/resources/views/core/taxa-search.blade.php
+++ b/resources/views/core/taxa-search.blade.php
@@ -1,5 +1,6 @@
 @props([
     'id' => uniqid(),
+    'name' => 'taxa',
     'tidName' => 'tid',
     'taxa_value' => '' ,
     'tid_value' => '',
@@ -27,7 +28,7 @@
         @endif
 
         <x-autocomplete-input
-            name="taxa"
+            :name="$name"
             :id="$id"
             :value="$taxa_value"
             placeholder="Type to search..."

--- a/routes/web.php
+++ b/routes/web.php
@@ -160,8 +160,8 @@ Route::group(['prefix' => '/collections'], function () {
     Route::get('/list', [CollectionController::class, 'listPage']);
     Route::get('/{collid}/import', [CollectionController::class, 'importPage']);
     Route::patch('/{collid}/stats', [CollectionController::class, 'updateStats']);
-    Route::get('/{collid}/skeletal', [CollectionController::class, 'skeletalView']);
-    Route::post('/{collid}/skeletal', [CollectionController::class, 'skeletalAdd']);
+    Route::get('/{collid}/skeletal', [CollectionController::class, 'skeletalView'])->can('COLL_EDIT', 'collid');
+    Route::post('/{collid}/skeletal', [CollectionController::class, 'skeletalAdd'])->can('COLL_EDIT', 'collid');
     Route::get('/{collid}', [CollectionController::class, 'collection']);
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -160,6 +160,8 @@ Route::group(['prefix' => '/collections'], function () {
     Route::get('/list', [CollectionController::class, 'listPage']);
     Route::get('/{collid}/import', [CollectionController::class, 'importPage']);
     Route::patch('/{collid}/stats', [CollectionController::class, 'updateStats']);
+    Route::get('/{collid}/skeletal', [CollectionController::class, 'skeletalView']);
+    Route::post('/{collid}/skeletal', [CollectionController::class, 'skeletalAdd']);
     Route::get('/{collid}', [CollectionController::class, 'collection']);
 });
 


### PR DESCRIPTION
# Issue #66

# Summary
Adds functional skeletal submit
- Supports same values
- Has dynamic input rendering
- Form is doing ajax to keep js session alive
- Js timers and rate functions are implemented
- Display Info Toggle implemented
- Success results in occid links along with img links to media tab.
- catalognumber field is required
- Adds name override for taxa search (needed to pass in correct request variable names)
- Adds passing for x-show to input so that it wraps the label as well as the input

# Pull Request Checklist During the Blitz Phase:

# Pre-Approval, Blitz Phase

- [x] Comment which GitHub issue(s), if any does this PR address
- [x] If more description is required, add a description section
- [ ] Are (basic) tests written to cover the new functionality?
- [x] If there is text in this PR that has not been internationalized, implementing this is not required; add a @TODO comment and create a github issue about it.
- [x] There are no linter errors
- [x] Has Pint been run?
- [x] Have the required updates to the .env.example been made?

# Code Review, Blitz Phase
- [ ] QA not required, but go ahead and do if the situation requires it
- [ ] PR should be squash merged
- [ ] Code reviewer can go ahead and merge a PR after approving the code review
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.